### PR TITLE
Changes for compatibility with python 3

### DIFF
--- a/decodes/__init__.py
+++ b/decodes/__init__.py
@@ -1,4 +1,4 @@
-print "http://decod.es"
+print("http://decod.es")
 
 """A Platform-Agnostic Computational Geometry Environment 
 
@@ -8,7 +8,7 @@ print "http://decod.es"
 
 class Outies:
     # list here all the outies we currently support
-    Rhino, Grasshopper, SVG , ACAD, Dynamo,ThreeJS,JSON = range(7)
+    Rhino, Grasshopper, SVG , ACAD, Dynamo,ThreeJS,JSON = list(range(7))
 
 
 # keep this up to date with what outies we support
@@ -67,7 +67,7 @@ def make_out(outtype, name="untitled", path=False, **kargs):
         import io.dynamo_out
         return io.dynamo_out.DynamoOut()
     else :
-        print "!!! hey, i don't have an outie of type foo !!!"
+        print("!!! hey, i don't have an outie of type foo !!!")
         return False
 
 # keep this up to date with what outies we support
@@ -77,5 +77,5 @@ def make_in(intype):
     if intype == innies.Dynamo:
         return innies.DynamoIn()
     if intype == innies.Foo:
-        if VERBOSE : print "!!! hey, i don't have an innie of type foo !!!"
+        if VERBOSE : print("!!! hey, i don't have an innie of type foo !!!")
         return False

--- a/decodes/core/__init__.py
+++ b/decodes/core/__init__.py
@@ -1,16 +1,17 @@
-print "decodes core loaded"
 
 VERBOSE_FS = False # determines if we verify file system loaded right
 VERBOSE = True
 
+if VERBOSE_FS: print("decodes core loaded")
+
 EPSILON = 1.0e-10
 
-from dc_interval import *
-from dc_color import *
+from .dc_interval import *
+from .dc_color import *
 
-from dc_base import *
-from dc_vec import *
-from dc_point import *
+from .dc_base import *
+from .dc_vec import *
+from .dc_point import *
 
 """
 VECTOR CONSTANTS
@@ -19,30 +20,30 @@ UX = Vec(1,0,0)
 UY = Vec(0,1,0)
 UZ = Vec(0,0,1)
 
-from dc_graph import *
+from .dc_graph import *
 
-from dc_bounds import *
+from .dc_bounds import *
 
-from dc_plane import *
-from dc_cs import *
+from .dc_plane import *
+from .dc_cs import *
 
-from dc_line import *
-from dc_circle import *
-from dc_tri import *
+from .dc_line import *
+from .dc_circle import *
+from .dc_tri import *
 
-from dc_raster import *
-from dc_grid import *
+from .dc_raster import *
+from .dc_grid import *
 
-from dc_has_pts import *
-from dc_pline import *
-from dc_mesh import *
-from dc_pgon import *
+from .dc_has_pts import *
+from .dc_pline import *
+from .dc_mesh import *
+from .dc_pgon import *
 
-from dc_xform import *
-from dc_intersection import *
+from .dc_xform import *
+from .dc_intersection import *
 
-from dc_curve import *
-from dc_surface import *
+from .dc_curve import *
+from .dc_surface import *
 
 """
 Shifts a List
@@ -56,4 +57,4 @@ def shift(lst,n=0):
 Matches Relative Indices within a List
 """   
 def match(lst,rel_idxs):
-    return zip(*[shift(lst,idx) for idx in rel_idxs])
+    return list(zip(*[shift(lst,idx) for idx in rel_idxs]))

--- a/decodes/core/dc_base.py
+++ b/decodes/core/dc_base.py
@@ -1,10 +1,10 @@
 from decodes.core import *
-if VERBOSE_FS: print "base.py loaded"
-import copy,exceptions, collections
+if VERBOSE_FS: print("base.py loaded")
+import copy, collections
 
 
 
-class GeometricError(StandardError):
+class GeometricError(Exception):
     pass
 
 class BasisError(GeometricError):

--- a/decodes/core/dc_circle.py
+++ b/decodes/core/dc_circle.py
@@ -1,6 +1,6 @@
 from decodes.core import *
 from . import dc_base, dc_interval, dc_vec, dc_point, dc_plane, dc_cs #here we may only import modules that have been loaded before this one.    see core/__init__.py for proper order
-if VERBOSE_FS: print "dc_circle.py loaded"
+if VERBOSE_FS: print("dc_circle.py loaded")
 
 import copy, collections
 import math

--- a/decodes/core/dc_cone.py
+++ b/decodes/core/dc_cone.py
@@ -1,0 +1,57 @@
+#!python
+
+from decodes.core import *
+# from . import dc_base, dc_interval, dc_vec, dc_point, dc_plane, dc_cs, dc_circle
+if VERBOSE_FS: print("dc_cone.py loaded")
+import math
+
+class Cone(Circle):
+    """
+    A 3d right circular cone class
+    
+    In the Cartesian coordinate system, an elliptic cone is the locus of an equation of the form:
+    x2   y2   z2
+    -- + -- = --
+    a2   b2   c2
+
+    """
+    def __init__(self, plane, radius, height):
+        self.height = height
+        super().__init__(plane, radius)
+    
+    def __repr__(self): return "cone[{0},{1},{2},{3},{4},{5} r:{6} h:{7}]".format(self.x,self.y,self.z,self._vec.x,self._vec.y,self._vec.z,self.rad,self.height)
+
+    def contains(self, pt):
+        # the axis vector, pointing from the base to the tip
+        cone_axis = self.normal * self.height
+        # project pt onto axis to find the point's distance along the axis:
+        cone_dist = math.sqrt(cone_axis.dot(pt - self.origin))
+        if cone_dist < 0 or cone_dist > self.height:
+            # point is above or below cone
+            return False
+
+        # Then you calculate the cone radius at that point along the axis:
+        cone_radius = (cone_dist / self.height) * self.rad
+        # And finally calculate the point's orthogonal distance from the axis to compare against the cone radius:
+        orth_distance = (pt - self.origin) - self.normal * cone_dist
+
+        if orth_distance > cone_radius:
+            # point is to the side of the cone
+            return False
+        return True
+
+    def volume(self):
+        """
+        V = 1/3 * Ab * h
+        """
+        return((math.pi * self.rad * 2.0 * self.height) / 3)
+
+# entry point
+if __name__ == "__main__":
+  print("main")
+  o = Cone(Plane(), 5.0, 10.0)
+
+  print(o)
+  print("contains %d" % (o.contains(Point(0.0, 0.0, 5.0))))
+  print("volume %f" % (o.volume()))
+

--- a/decodes/core/dc_cs.py
+++ b/decodes/core/dc_cs.py
@@ -1,6 +1,6 @@
 from decodes.core import *
 from . import dc_base, dc_vec, dc_point #here we may only import modules that have been loaded before this one.    see core/__init__.py for proper order
-if VERBOSE_FS: print "cs.py loaded"
+if VERBOSE_FS: print("cs.py loaded")
 import math, copy, collections
 
 class CS(Geometry, Basis):

--- a/decodes/core/dc_curve.py
+++ b/decodes/core/dc_curve.py
@@ -1,6 +1,6 @@
 from decodes.core import *
 from . import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon
-if VERBOSE_FS: print "curve.py loaded"
+if VERBOSE_FS: print("curve.py loaded")
 
 import math
 

--- a/decodes/core/dc_cylinder.py
+++ b/decodes/core/dc_cylinder.py
@@ -1,0 +1,34 @@
+#!python
+
+from decodes.core import *
+# from . import dc_base, dc_interval, dc_vec, dc_point, dc_plane, dc_cs, dc_circle
+if VERBOSE_FS: print("dc_cylinder.py loaded")
+
+
+
+class Cylinder(Circle):
+    """
+    right circular cylinder
+    CircleGeometry(radius, segments, thetaStart, thetaLength)
+    PlaneGeometry(width, height, widthSegments, heightSegments)
+    CylinderGeometry(radiusTop, radiusBottom, height, radiusSegments, heightSegments, openEnded, thetaStart, thetaLength)
+
+    """
+    def __init__(self, plane, radius, height):
+        self.height = height
+        super().__init__(plane, radius)
+    
+    def __repr__(self): return "cylinder[{0},{1},{2},{3},{4},{5} r:{6} h:{7}]".format(self.x,self.y,self.z,self._vec.x,self._vec.y,self._vec.z,self.rad,self.height)
+
+    def contains(self, pt):
+        if(self.near_pt(pt).dist(self) >= self.rad):
+            return False
+        return super().contains(pt, self.height * 0.5)
+
+# entry point
+if __name__ == "__main__":
+  print("main")
+  o = Cylinder(Plane(), 5, 10)
+
+  print(o)
+  print("contains %d" % (o.contains(Point(4.5,0,4.9))))

--- a/decodes/core/dc_graph.py
+++ b/decodes/core/dc_graph.py
@@ -1,6 +1,6 @@
 from decodes.core import *
 from . import dc_base, dc_vec, dc_point #here we may only import modules that have been loaded before this one.    see core/__init__.py for proper order
-if VERBOSE_FS: print "graph.py loaded"
+if VERBOSE_FS: print("graph.py loaded")
 
 import math, itertools
 
@@ -41,13 +41,13 @@ class Graph(object):
     def node_list(self):
         return list(self.nodes)
 
-    def __repr__(self): return "graph[{0} nodes ,{1} connections]".format(len(self.nodes),sum([len(edge) for edge in self.edges.values()]))
+    def __repr__(self): return "graph[{0} nodes ,{1} connections]".format(len(self.nodes),sum([len(edge) for edge in list(self.edges.values())]))
 
 
     @property
     def node_pairs(self):
         ret = []
-        for n1, others in self.edges.iteritems():
+        for n1, others in self.edges.items():
              for n2 in others: ret.append((n1,n2))
         return tuple(ret)
     
@@ -165,7 +165,7 @@ class SpatialGraph(Graph):
         
         
     def to_segs(self):
-        return [[Segment(spt,ept) for ept in epts] for spt, epts in self.edges.items()]
+        return [[Segment(spt,ept) for ept in epts] for spt, epts in list(self.edges.items())]
         
         
     def __contains__(self, pt):

--- a/decodes/core/dc_grid.py
+++ b/decodes/core/dc_grid.py
@@ -120,8 +120,8 @@ class Grid(Raster):
         dx = 1 if pt.x > self._ivals_x[add[0]].mid else -1
         dy = 1 if pt.y > self._ivals_y[add[1]].mid else -1
         adds = [add,(add[0]+dx,add[1]),(add[0]+dx,add[1]+dy),(add[0],add[1]+dy)]
-        adds = filter(lambda add: add[0]>=0 and add[0]<self.px_width, adds)
-        adds = filter(lambda add: add[1]>=0 and add[1]<self.px_height, adds)
+        adds = [add for add in adds if add[0]>=0 and add[0]<self.px_width]
+        adds = [add for add in adds if add[1]>=0 and add[1]<self.px_height]
         return sorted(adds)
         
     def _recalculate_base_pts(self):

--- a/decodes/core/dc_has_pts.py
+++ b/decodes/core/dc_has_pts.py
@@ -1,7 +1,7 @@
 from decodes.core import *
 from . import dc_base, dc_interval, dc_vec, dc_point, dc_plane, dc_cs #here we may only import modules that have been loaded before this one.    see core/__init__.py for proper order
 import math, random, copy
-if VERBOSE_FS: print "has_pts.py loaded"
+if VERBOSE_FS: print("has_pts.py loaded")
 
 
 class HasPts(HasBasis):

--- a/decodes/core/dc_intersection.py
+++ b/decodes/core/dc_intersection.py
@@ -1,6 +1,6 @@
 from decodes.core import *
 from . import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon
-if VERBOSE_FS: print "intersection.py loaded"
+if VERBOSE_FS: print("intersection.py loaded")
 
 
 

--- a/decodes/core/dc_line.py
+++ b/decodes/core/dc_line.py
@@ -1,7 +1,7 @@
 from decodes.core import *
 
 from . import dc_base, dc_interval, dc_color, dc_vec, dc_point #here we may only import modules that have been loaded before this one.  see core/__init__.py for proper order
-if VERBOSE_FS: print "line.py loaded"
+if VERBOSE_FS: print("line.py loaded")
 
 #from SYMPY
 #http://code.google.com/p/sympy/source/browse/trunk.freezed/sympy/geometry/entity.py

--- a/decodes/core/dc_mesh.py
+++ b/decodes/core/dc_mesh.py
@@ -1,6 +1,6 @@
 from decodes.core import *
 from . import dc_base, dc_vec, dc_point, dc_has_pts #here we may only import modules that have been loaded before this one.    see core/__init__.py for proper order
-if VERBOSE_FS: print "mesh.py loaded"
+if VERBOSE_FS: print("mesh.py loaded")
 
 import copy, collections
 

--- a/decodes/core/dc_pgon.py
+++ b/decodes/core/dc_pgon.py
@@ -1,6 +1,6 @@
 from decodes.core import *
 from . import dc_base, dc_interval, dc_vec, dc_point, dc_cs, dc_has_pts #here we may only import modules that have been loaded before this one.    see core/__init__.py for proper order
-if VERBOSE_FS: print "polygon.py loaded"
+if VERBOSE_FS: print("polygon.py loaded")
 
 import copy, collections
 import math

--- a/decodes/core/dc_plane.py
+++ b/decodes/core/dc_plane.py
@@ -1,6 +1,6 @@
 from decodes.core import *
 from . import dc_base, dc_vec, dc_point #here we may only import modules that have been loaded before this one.    see core/__init__.py for proper order
-if VERBOSE_FS: print "plane.py loaded"
+if VERBOSE_FS: print("plane.py loaded")
 import math
 
 

--- a/decodes/core/dc_pline.py
+++ b/decodes/core/dc_pline.py
@@ -1,6 +1,6 @@
 from decodes.core import *
 from . import dc_base, dc_vec, dc_point, dc_has_pts #here we may only import modules that have been loaded before this one.    see core/__init__.py for proper order
-if VERBOSE_FS: print "pline.py loaded"
+if VERBOSE_FS: print("pline.py loaded")
 
 import copy, collections
 
@@ -103,7 +103,7 @@ class PLine(HasPts):
             for s in self : pts.append(s)
             for o in other : pts.append(o)
             pts.pop(len(self))
-            print len(self)
+            print(len(self))
             jpline= PLine(pts)
             return jpline
             
@@ -138,7 +138,7 @@ class PLine(HasPts):
             for s in self : pts.append(s)
             for o in other : pts.append(o)
             jpline= PLine(pts)
-            print "new segment created"
+            print("new segment created")
             return jpline
             
     def seg(self,idx):

--- a/decodes/core/dc_point.py
+++ b/decodes/core/dc_point.py
@@ -1,7 +1,7 @@
 from decodes.core import *
 from . import dc_base, dc_vec #here we may only import modules that have been loaded before this one.    see core/__init__.py for proper order
 import math, random, warnings, copy
-if VERBOSE_FS: print "point.py loaded"
+if VERBOSE_FS: print("point.py loaded")
 
 
 # points may define a "basis"

--- a/decodes/core/dc_raster.py
+++ b/decodes/core/dc_raster.py
@@ -205,7 +205,7 @@ class Image(Raster):
         filename = filename + ".tga"
 
         if verbose:
-            print "saving image to ",os.path.join(path, filename)
+            print("saving image to ",os.path.join(path, filename))
             from time import time
             t0 = time()
 
@@ -234,7 +234,7 @@ class Image(Raster):
                                         BPP, Orientation)
 
         # Array mdule and format documentation at:  http://docs.python.org/library/array.html
-        data = array.array("B", (255 for i in xrange(self.px_width * self.px_height * 3)))
+        data = array.array("B", (255 for i in range(self.px_width * self.px_height * 3)))
 
         for n,clr in enumerate(self._pixels):
             data[n * 3] = int(clr.b*255)
@@ -243,10 +243,10 @@ class Image(Raster):
 
         if verbose: 
             t1 = time()
-            print 'packing data took: %f' %(t1-t0)
+            print('packing data took: %f' %(t1-t0))
 
         if not os.path.exists(path):
-            if verbose : print "creating folder",path
+            if verbose : print("creating folder",path)
             os.makedirs(path)
         
         datafile = open(os.path.join(path, filename), "wb")
@@ -256,7 +256,7 @@ class Image(Raster):
 
         if verbose: 
             t2 = time()
-            print 'writing file took: %f' %(t2-t1)
+            print('writing file took: %f' %(t2-t1))
 
 
 

--- a/decodes/core/dc_surface.py
+++ b/decodes/core/dc_surface.py
@@ -1,6 +1,6 @@
 from decodes.core import *
 from . import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon, dc_curve
-if VERBOSE_FS: print "surface.py loaded"
+if VERBOSE_FS: print("surface.py loaded")
 
 
 
@@ -367,7 +367,7 @@ class Surface(IsParametrized):
         # * eliminate when we have a matrix class or can import numpy
         def matrix_mult(matrix1,matrix2):
             if len(matrix1[0]) != len(matrix2):
-                print "Matrices can't be multiplied!"
+                print("Matrices can't be multiplied!")
             else:
                 m = len(matrix1)
                 n = len(matrix1[0])

--- a/decodes/core/dc_tri.py
+++ b/decodes/core/dc_tri.py
@@ -1,6 +1,6 @@
 from decodes.core import *
 from . import dc_base, dc_vec, dc_point, dc_line, dc_plane #here we may only import modules that have been loaded before this one.    see core/__init__.py for proper order
-if VERBOSE_FS: print "tri.py loaded"
+if VERBOSE_FS: print("tri.py loaded")
 
 class Tri(Geometry):
     
@@ -41,7 +41,7 @@ class Tri(Geometry):
     @property
     def circumcenter(self):
         #http://www.mathopenref.com/trianglecircumcenter.html
-        from .dc_intersection import *
+        from  dc_intersection import Intersector
         xsec = Intersector()
         bsec_ab = self.edge_bisector(0)
         bsec_bc = self.edge_bisector(1)
@@ -60,7 +60,7 @@ class Tri(Geometry):
     @property
     def incenter(self):
         #http://www.mathopenref.com/triangleincenter.html
-        from .dc_intersection import *
+        from  dc_intersection import Intersector
         xsec = Intersector()
         bsec_ab = self.angle_bisector(0)
         bsec_bc = self.angle_bisector(1)

--- a/decodes/core/dc_vec.py
+++ b/decodes/core/dc_vec.py
@@ -2,7 +2,7 @@ from decodes.core import *
 from . import dc_base #here we may only import modules that have been loaded before this one.    see core/__init__.py for proper order
 
 import math, random
-if VERBOSE_FS: print "vec.py loaded"
+if VERBOSE_FS: print("vec.py loaded")
 
 
 

--- a/decodes/core/dc_xform.py
+++ b/decodes/core/dc_xform.py
@@ -2,7 +2,7 @@ from decodes.core import *
 from . import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon
 
 
-if VERBOSE_FS: print "xform.py loaded"
+if VERBOSE_FS: print("xform.py loaded")
 
 class Xform(object):
     """
@@ -97,7 +97,7 @@ class Xform(object):
         
         xf = Xform()
         
-        if isinstance(plane, basestring):
+        if isinstance(plane, str):
             if plane=="world_xy" : xf.c33 *= -1
             elif plane=="world_xz" : xf.c22 *= -1
             elif plane=="world_yz" : xf.c11 *= -1

--- a/decodes/extensions/__init__.py
+++ b/decodes/extensions/__init__.py
@@ -1,1 +1,1 @@
-print "extensions loaded"
+print("extensions loaded")

--- a/decodes/extensions/cellular_automata.py
+++ b/decodes/extensions/cellular_automata.py
@@ -1,7 +1,7 @@
 from ..core import *
 from ..core import dc_color, dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon, dc_xform
 import copy
-print "cellular_automata.py loaded"
+print("cellular_automata.py loaded")
 
 class CA (object):
 

--- a/decodes/extensions/lsystem.py
+++ b/decodes/extensions/lsystem.py
@@ -2,7 +2,7 @@ from ..core import *
 from math import *
 from ..core import dc_color, dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon, dc_xform
 import copy
-print "lsystem.py loaded"
+print("lsystem.py loaded")
 
 
 class LEngine(object):

--- a/decodes/extensions/packing.py
+++ b/decodes/extensions/packing.py
@@ -50,7 +50,7 @@ class Strip():
             result.append(self.filling)
             if self.remainder != None : 
                 r = self.remainder.get_filled()
-                if r <> [] : result.extend(r)
+                if r != [] : result.extend(r)
         return result
 
 
@@ -70,9 +70,9 @@ def bin_strips(lengths = [], stock_size = Interval(100,100)):
             flag = False
             for j, s in enumerate(strips):
                 test_strip = s.can_fit(r)
-                if test_strip <> None:
+                if test_strip != None:
                     test_strip.put_item(r)
-                    print "packing into strip ",j
+                    print("packing into strip ",j)
                     flag = True
                     break
             # if we get here we have not placed the rectangle
@@ -81,7 +81,7 @@ def bin_strips(lengths = [], stock_size = Interval(100,100)):
                 strips.append(Strip(no_strips*stock_size.a, stock_size.b))
                 no_strips += 1
                 strips[no_strips-1].put_item(r)
-                print "adding strip ", no_strips-1
+                print("adding strip ", no_strips-1)
 
         return strips
 
@@ -193,7 +193,7 @@ class Bin():
         else:
             for i in range(1,len(self.filling)) :
                 result = self.filling[i].can_fit(shape)
-                if  result<> None : return result
+                if  result!= None : return result
         return None
 
     def get_polygons(self, bin_filled = Color(1), bin_edges = Color(.5)):
@@ -271,7 +271,7 @@ def bin_polygons(shapes = [], sheet_size = Interval(100,100)):
             flag = False
             for j, s in enumerate(sheets):
                 test_bin = s.can_fit(r)
-                if test_bin <> None:
+                if test_bin != None:
                     test_bin.put_item(r)
 #                    print "packing into bin ",j
                     flag = True

--- a/decodes/extensions/parse_epw.py
+++ b/decodes/extensions/parse_epw.py
@@ -30,7 +30,7 @@ def epw_metadata(path):
     out: a dict containing EPW metadata
     """
     with open(path) as myfile:
-        head=[myfile.next() for x in xrange(number_of_epw_header_lines)]
+        head=[next(myfile) for x in range(number_of_epw_header_lines)]
     
     #city,state/province/region,country,data source,wmo number,lat,long,timezone,elevation
     #LOCATION,San Francisco Intl Ap,CA,USA,TMY3,724940,37.62,-122.40,-8.0,2.0
@@ -68,7 +68,7 @@ def parse_epw_file(path, desired_keys):
 
 def _parse_epw_line(string, desired_keys):
     vals = string.split(",")
-    if isinstance(desired_keys, basestring):
+    if isinstance(desired_keys, str):
         return float(vals[epw_keycols[desired_keys]])
     else : 
         return {k:float(vals[epw_keycols[k]]) for k in desired_keys}

--- a/decodes/extensions/poisson_sampling.py
+++ b/decodes/extensions/poisson_sampling.py
@@ -79,7 +79,7 @@ class Poisson_Sampler():
                 
             cycles+=1
             if cycles > max_cycles:
-                print 'stopped after {} cycles'.format(max_cycles)
+                print('stopped after {} cycles'.format(max_cycles))
                 break
         
         return sample_points

--- a/decodes/extensions/reaction_diffusion.py
+++ b/decodes/extensions/reaction_diffusion.py
@@ -1,7 +1,7 @@
 from ..core import *
 from ..core import dc_color, dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon, dc_xform
 import copy
-print "reaction_diffusion.py loaded"
+print("reaction_diffusion.py loaded")
 
 class GrayScott (object):
 

--- a/decodes/extensions/tiling_danzer.py
+++ b/decodes/extensions/tiling_danzer.py
@@ -61,7 +61,7 @@ class DzTile(object):
         factor = tau_pow[self.rlvl]
         xf_scale = Xform.scale(factor)
         # return an world-space copy of each base_pt 
-        return map(lambda pt:(pt*xf_scale)*self.xf,self._base_pts)
+        return [(pt*xf_scale)*self.xf for pt in self._base_pts]
         
     """
     Constructs a child tile of the specified type, positioned by matching a CS on this tile with a CS on the desired child tile

--- a/decodes/io/__init__.py
+++ b/decodes/io/__init__.py
@@ -1,1 +1,1 @@
-print "io loaded"
+print("io loaded")

--- a/decodes/io/autocad_out.py
+++ b/decodes/io/autocad_out.py
@@ -2,7 +2,7 @@ from .. import *
 from ..core import *
 from ..core import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_pline, dc_mesh, dc_pgon
 from . import outie
-if VERBOSE_FS: print "autocad-out loaded"
+if VERBOSE_FS: print("autocad-out loaded")
 
 from decodes.io.pyautocad import *
 

--- a/decodes/io/dynamo_in.py
+++ b/decodes/io/dynamo_in.py
@@ -1,7 +1,7 @@
 from .. import *
 from ..core import *
 from ..core import dc_color, dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon, dc_xform, dc_intersection
-if VERBOSE_FS: print "dynamo_in loaded"
+if VERBOSE_FS: print("dynamo_in loaded")
 
 
 import clr, collections
@@ -87,13 +87,13 @@ class DynamoIn():
         elif any(p in str(type(dyn_in)) for p in DynamoIn.structure_types): 
             return dyn_in
         else :
-            print "UNKNOWN TYPE: "+str(type(dyn_in))+" is an "+ str(type(dyn_in))
+            print("UNKNOWN TYPE: "+str(type(dyn_in))+" is an "+ str(type(dyn_in)))
             #print inspect.getmro(dyn_in.__class__)
             #if issubclass(dyn_in.__class__, ds.GeometryBase ) : print "this is geometry"
             #print dyn_incoming.TypeHint
             #print dyn_incoming.Description
 
-def _should_iterate(item): return isinstance(item, collections.Iterable) and not isinstance(item,basestring)
+def _should_iterate(item): return isinstance(item, collections.Iterable) and not isinstance(item,str)
 
 def from_dynvec(dyn_vec):
     return Vec(dyn_vec.X,dyn_vec.Y,dyn_vec.Z)

--- a/decodes/io/dynamo_out.py
+++ b/decodes/io/dynamo_out.py
@@ -2,7 +2,7 @@ from .. import *
 from ..core import *
 from ..core import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_pline, dc_mesh, dc_pgon
 from . import outie
-if VERBOSE_FS: print "dynamo_out loaded"
+if VERBOSE_FS: print("dynamo_out loaded")
 
 import clr, collections
 
@@ -26,7 +26,7 @@ class DynamoOut(outie.Outie):
         
     def _is_leaf(self, items): return not any(self._should_iterate(item) for item in items)
 
-    def _should_iterate(self, item): return isinstance(item, collections.Iterable) and not isinstance(item,basestring)
+    def _should_iterate(self, item): return isinstance(item, collections.Iterable) and not isinstance(item,str)
     
     def _drawGeom(self, g):
         # here we sort out what type of geometry we're dealing with, and call the proper draw functions

--- a/decodes/io/gh_in.py
+++ b/decodes/io/gh_in.py
@@ -2,7 +2,7 @@ from .. import *
 from ..core import *
 from ..core import dc_color, dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon, dc_xform, dc_intersection
 from .rhino_in import *
-if VERBOSE_FS: print "gh_in loaded"
+if VERBOSE_FS: print("gh_in loaded")
 
 import Rhino.Geometry as rg
 import System.Drawing.Color
@@ -76,7 +76,7 @@ class GrasshopperIn():
         elif any(p in str(type(gh_in)) for p in GrasshopperIn.friendly_types) : return gh_in
         elif any(p in str(type(gh_in)) for p in GrasshopperIn.structure_types) : return gh_in
         else :
-            print "UNKNOWN TYPE: "+gh_in_str+" is an "+ str(type(gh_in))
+            print("UNKNOWN TYPE: "+gh_in_str+" is an "+ str(type(gh_in)))
             return gh_in
             #print inspect.getmro(gh_in.__class__)
             #if issubclass(gh_in.__class__, rg.GeometryBase ) : print "this is geometry"

--- a/decodes/io/gh_in.py
+++ b/decodes/io/gh_in.py
@@ -2,7 +2,7 @@ from .. import *
 from ..core import *
 from ..core import dc_color, dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon, dc_xform, dc_intersection
 from .rhino_in import *
-if VERBOSE_FS: print("gh_in loaded")
+if VERBOSE_FS: print "gh_in loaded"
 
 import Rhino.Geometry as rg
 import System.Drawing.Color
@@ -60,6 +60,12 @@ class GrasshopperIn():
             if (ispolyline) : return from_rgpolyline(gh_polyline)
         elif type(gh_in) is rg.Polyline:
             return from_rgpolyline(gh_in)
+        
+        # ksteinfe add 3/20/17
+        elif type(gh_in) is rg.PolyCurve: 
+            ispolyline, gh_polyline = gh_in.TryGetPolyline()
+            if (ispolyline) : return from_rgpolyline(gh_polyline)
+            
         elif type(gh_in) is rg.NurbsCurve : 
             #TODO: check if gh_in can be described as a line first...
             ispolyline, gh_polyline = gh_in.TryGetPolyline()
@@ -76,7 +82,7 @@ class GrasshopperIn():
         elif any(p in str(type(gh_in)) for p in GrasshopperIn.friendly_types) : return gh_in
         elif any(p in str(type(gh_in)) for p in GrasshopperIn.structure_types) : return gh_in
         else :
-            print("UNKNOWN TYPE: "+gh_in_str+" is an "+ str(type(gh_in)))
+            print "UNKNOWN TYPE: "+gh_in_str+" is an "+ str(type(gh_in))
             return gh_in
             #print inspect.getmro(gh_in.__class__)
             #if issubclass(gh_in.__class__, rg.GeometryBase ) : print "this is geometry"

--- a/decodes/io/gh_out.py
+++ b/decodes/io/gh_out.py
@@ -3,7 +3,7 @@ from ..core import *
 from ..core import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_pline, dc_mesh, dc_pgon
 from .rhino_out import *
 from . import outie
-if VERBOSE_FS: print "gh_out loaded"
+if VERBOSE_FS: print("gh_out loaded")
 
 import clr, collections
 import Rhino.Geometry as rg
@@ -46,7 +46,7 @@ class GrasshopperOut(outie.Outie):
         
     def _is_leaf(self, items): return not any(self._should_iterate(item) for item in items)
 
-    def _should_iterate(self, item): return isinstance(item, collections.Iterable) and not isinstance(item,basestring)
+    def _should_iterate(self, item): return isinstance(item, collections.Iterable) and not isinstance(item,str)
     
     def _add_branch(self, g, tree, tree_p, path):
         # here we sort out what type of geometry we're dealing with, and call the proper draw functions

--- a/decodes/io/json_out.py
+++ b/decodes/io/json_out.py
@@ -2,11 +2,11 @@ from .. import *
 from ..core import *
 from ..core import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon
 from . import outie
-if VERBOSE_FS: print "json_out loaded"
+if VERBOSE_FS: print("json_out loaded")
 
 import os, sys, math
-import cStringIO
-import jsonpickle
+import io
+from . import jsonpickle
 
 class JsonOut(outie.Outie):
     """outie for writing stuff to a ThreeJS scene file"""
@@ -171,7 +171,7 @@ class JsonOut(outie.Outie):
         self._json = jsonpickle.encode(self.geom)
         
         if self._save_file: 
-            print "drawing js to "+self.filepath
+            print("drawing js to "+self.filepath)
             # write buffer to file
             fo = open(self.filepath, "wb")
             fo.write( self.json )

--- a/decodes/io/jsonpickle/__init__.py
+++ b/decodes/io/jsonpickle/__init__.py
@@ -62,10 +62,10 @@ added to JSON.
 
 
 """
-import pickler
-import unpickler
-from backend import JSONBackend
-from version import VERSION
+from . import pickler
+from . import unpickler
+from .backend import JSONBackend
+from .version import VERSION
 
 # ensure built-in handlers are loaded
 #__import__('jsonpickle.handlers')

--- a/decodes/io/jsonpickle/_samples.py
+++ b/decodes/io/jsonpickle/_samples.py
@@ -87,7 +87,7 @@ class GetstateDict(dict):
         self.active = False
 
     def __getstate__(self):
-        return (self.name, dict(self.items()))
+        return (self.name, dict(list(self.items())))
 
     def __setstate__(self, state):
         self.name, vals = state

--- a/decodes/io/jsonpickle/backend.py
+++ b/decodes/io/jsonpickle/backend.py
@@ -1,4 +1,4 @@
-from compat import PY32
+from .compat import PY32
 
 class JSONBackend(object):
     """Manages encoding and decoding using various backends.

--- a/decodes/io/jsonpickle/compat.py
+++ b/decodes/io/jsonpickle/compat.py
@@ -17,16 +17,16 @@ except NameError:
     set = set
 
 try:
-    unicode = unicode
+    str = str
 except NameError:
-    unicode = str
+    str = str
 
 try:
-    long = long
+    long = int
 except NameError:
     long = int
 
 try:
-    unichr = unichr
+    chr = chr
 except NameError:
-    unichr = chr
+    chr = chr

--- a/decodes/io/jsonpickle/handlers.py
+++ b/decodes/io/jsonpickle/handlers.py
@@ -26,8 +26,8 @@ import time
 import collections
 import decimal
 
-import util
-from compat import unicode
+from . import util
+from .compat import str
 
 
 class Registry(object):
@@ -101,7 +101,7 @@ class DatetimeHandler(BaseHandler):
     def flatten(self, obj, data):
         pickler = self.context
         if not pickler.unpicklable:
-            return unicode(obj)
+            return str(obj)
         cls, args = obj.__reduce__()
         flatten = pickler.flatten
         payload = util.b64encode(args[0])

--- a/decodes/io/jsonpickle/pickler.py
+++ b/decodes/io/jsonpickle/pickler.py
@@ -7,12 +7,13 @@
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution.
 
-import util as util
-import tags as tags
-import handlers as handlers
+from . import util as util
+from . import tags as tags
+from . import handlers as handlers
 
-from backend import JSONBackend
-from compat import unicode
+from .backend import JSONBackend
+from .compat import str
+import collections
 
 
 def encode(value,
@@ -217,7 +218,7 @@ class Pickler(object):
                 data[tags.REPR] = '%s/%s' % (obj.__name__,
                                              obj.__name__)
             else:
-                data = unicode(obj)
+                data = str(obj)
             return data
 
         if util.is_dictionary_subclass(obj):
@@ -254,11 +255,11 @@ class Pickler(object):
             data = obj.__class__()
 
         flatten = self._flatten_key_value_pair
-        for k, v in sorted(obj.items(), key=util.itemgetter):
+        for k, v in sorted(list(obj.items()), key=util.itemgetter):
             flatten(k, v, data)
 
         # the collections.defaultdict protocol
-        if hasattr(obj, 'default_factory') and callable(obj.default_factory):
+        if hasattr(obj, 'default_factory') and isinstance(obj.default_factory, collections.Callable):
             flatten('default_factory', obj.default_factory, data)
 
         return data
@@ -274,7 +275,7 @@ class Pickler(object):
         """Flatten a key/value pair into the passed-in dictionary."""
         if not util.is_picklable(k, v):
             return data
-        if not isinstance(k, (str, unicode)):
+        if not isinstance(k, str):
             if self.keys:
                 k = tags.JSON_KEY + encode(k,
                                            reset=False, keys=True,
@@ -284,7 +285,7 @@ class Pickler(object):
                 try:
                     k = repr(k)
                 except:
-                    k = unicode(k)
+                    k = str(k)
         data[k] = self._flatten(v)
         return data
 

--- a/decodes/io/jsonpickle/tags.py
+++ b/decodes/io/jsonpickle/tags.py
@@ -6,7 +6,7 @@ created by the Pickler class.  The Unpickler uses
 these custom key names to identify dictionaries
 that need to be specially handled.
 """
-from compat import set
+from .compat import set
 
 ID = 'py_id'
 OBJECT = 'py_object'

--- a/decodes/io/jsonpickle/unpickler.py
+++ b/decodes/io/jsonpickle/unpickler.py
@@ -9,12 +9,12 @@
 
 import sys
 
-import util as util
-import tags as tags
-import handlers as handlers
+from . import util as util
+from . import tags as tags
+from . import handlers as handlers
 
-from compat import set
-from backend import JSONBackend
+from .compat import set
+from .backend import JSONBackend
 
 
 def decode(string, backend=None, context=None, keys=False, reset=True,
@@ -155,7 +155,7 @@ class Unpickler(object):
         return self._restore_object_instance_variables(obj, instance)
 
     def _restore_object_instance_variables(self, obj, instance):
-        for k, v in sorted(obj.items(), key=util.itemgetter):
+        for k, v in sorted(list(obj.items()), key=util.itemgetter):
             # ignore the reserved attribute
             if k in tags.RESERVED:
                 continue
@@ -204,7 +204,7 @@ class Unpickler(object):
 
     def _restore_dict(self, obj):
         data = {}
-        for k, v in sorted(obj.items(), key=util.itemgetter):
+        for k, v in sorted(list(obj.items()), key=util.itemgetter):
             self._namestack.append(k)
             if self.keys and k.startswith(tags.JSON_KEY):
                 k = decode(k[len(tags.JSON_KEY):],

--- a/decodes/io/jsonpickle/util.py
+++ b/decodes/io/jsonpickle/util.py
@@ -14,16 +14,16 @@ import operator
 import time
 import types
 
-import tags
-from compat import set
-from compat import unicode
-from compat import long
-from compat import PY3
+from . import tags
+from .compat import set
+from .compat import str
+from .compat import int
+from .compat import PY3
 
 
 SEQUENCES = (list, set, tuple)
 SEQUENCES_SET = set(SEQUENCES)
-PRIMITIVES = set((str, unicode, bool, float, int, long))
+PRIMITIVES = set((str, str, bool, float, int, int))
 
 
 def is_type(obj):
@@ -42,7 +42,7 @@ def is_type(obj):
     if PY3:
         return type(obj) is type
     else:
-        return type(obj) is type or type(obj) is types.ClassType
+        return type(obj) is type or type(obj) is type
 
 
 def is_object(obj):
@@ -293,4 +293,4 @@ def b64decode(payload):
 
 
 def itemgetter(obj, getter=operator.itemgetter(0)):
-    return unicode(getter(obj))
+    return str(getter(obj))

--- a/decodes/io/outie.py
+++ b/decodes/io/outie.py
@@ -2,7 +2,7 @@ from decodes import *
 from decodes.core import *
 from decodes.core import dc_base, dc_color
 
-if VERBOSE_FS: print "outie loaded"
+if VERBOSE_FS: print("outie loaded")
 import copy, collections
 
 class Outie(object):
@@ -46,14 +46,14 @@ class Outie(object):
         #returns a list of successful writes
         self._startDraw()
         try:
-            results = map(self._drawGeom, self.geom)
+            results = list(map(self._drawGeom, self.geom))
             if False in results:
-                print "dump not completely successful, the following geometry was not written:"
+                print("dump not completely successful, the following geometry was not written:")
                 i = -1
                 try:
                     while 1:
                         i = results.index(False, i+1)
-                        print str(i) , self.geom[i]
+                        print(str(i) , self.geom[i])
                 except ValueError:
                     pass
         

--- a/decodes/io/processing_out.py
+++ b/decodes/io/processing_out.py
@@ -1,8 +1,8 @@
 from decodes import *
 from decodes.core import *
 from decodes.core import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_pline, dc_mesh, dc_pgon
-import outie
-if VERBOSE_FS: print "processing_out loaded"
+from . import outie
+if VERBOSE_FS: print("processing_out loaded")
 
 class ProcessingOut(outie.Outie):
     """outie for pushing stuff to a processing applet"""
@@ -41,7 +41,7 @@ class ProcessingOut(outie.Outie):
         self.app.sphereDetail(0)
         
         if hasattr(self, 'color'):
-            print 'this outie has been assigned a color, i should set the pen now'
+            print('this outie has been assigned a color, i should set the pen now')
     
     def _endDraw(self):
         #print 'i have finihsed drawing stuff to the outie'
@@ -51,7 +51,7 @@ class ProcessingOut(outie.Outie):
         # here we sort out what type of geometry we're dealing with, and call the proper draw functions
         # MUST LOOK FOR CHILD CLASSES BEFORE PARENT CLASSES (points before vecs)
         if hasattr(g, 'props') and 'color' in g.props:
-            print 'this object has its own color assigned'
+            print('this object has its own color assigned')
         
         if isinstance(g, Mesh) : 
             return self._drawMesh(g)

--- a/decodes/io/pyautocad/__init__.py
+++ b/decodes/io/pyautocad/__init__.py
@@ -12,5 +12,5 @@
 __docformat__ = 'restructuredtext en'
 __version__ = '0.1.2'
 
-from api import *
-from types import *
+from .api import *
+from .types import *

--- a/decodes/io/pyautocad/api.py
+++ b/decodes/io/pyautocad/api.py
@@ -23,7 +23,7 @@ except Exception:
     # we are under readthedocs.org and need to mock this
     ACAD = None
 
-import types
+from . import types
 
 logger = logging.getLogger(__name__)
 
@@ -102,12 +102,12 @@ class Autocad(object):
             block = self.doc.ActiveLayout.Block
         object_names = object_name_or_list
         if object_names:
-            if isinstance(object_names, basestring):
+            if isinstance(object_names, str):
                 object_names = [object_names]
             object_names = [n.lower() for n in object_names]
 
         count = block.Count
-        for i in xrange(count):
+        for i in range(count):
             item = block.Item(i)  # it's faster than `for item in block`
             if limit and i >= limit:
                 return
@@ -150,7 +150,7 @@ class Autocad(object):
         """ Prints text in console and in `AutoCAD` prompt
         """
         print(text)
-        self.doc.Utility.Prompt(u"%s\n" % text)
+        self.doc.Utility.Prompt("%s\n" % text)
 
     def get_selection(self, text="Select objects"):
         """ Asks user to select objects

--- a/decodes/io/pyautocad/cache.py
+++ b/decodes/io/pyautocad/cache.py
@@ -98,11 +98,11 @@ if __name__ == "__main__":
     class Foo(object):
         @property
         def x(self):
-            print 'consuming time'
+            print('consuming time')
             time.sleep(1)
             return 42
 
     foo = Foo()
     cached_foo = Cached(foo)
     for i in range(5):
-        print cached_foo.x
+        print(cached_foo.x)

--- a/decodes/io/pyautocad/contrib/tables.py
+++ b/decodes/io/pyautocad/contrib/tables.py
@@ -160,9 +160,9 @@ class _TableImporter(object):
     def read_xls(self, stream):
         book = xlrd.open_workbook(file_contents=stream.read())
         sheet = book.sheet_by_index(0)
-        for row in xrange(sheet.nrows):
+        for row in range(sheet.nrows):
             columns = []
-            for col in xrange(sheet.ncols):
+            for col in range(sheet.ncols):
                 val = sheet.cell(row, col).value
                 columns.append(val)
             yield columns

--- a/decodes/io/pyautocad/utils.py
+++ b/decodes/io/pyautocad/utils.py
@@ -48,7 +48,7 @@ def mtext_to_string(s):
 
     """
 
-    return unformat_mtext(s).replace(u'\\P', u'\n')
+    return unformat_mtext(s).replace('\\P', '\n')
 
 
 def string_to_mtext(s):
@@ -56,7 +56,7 @@ def string_to_mtext(s):
 
     Replaces newllines `\\\\n` with `\\\\P`, etc.
     """
-    return s.replace('\\', '\\\\').replace(u'\n', u'\P')
+    return s.replace('\\', '\\\\').replace('\n', '\P')
 
 
 def text_width(text_item):
@@ -88,7 +88,7 @@ def suppressed_regeneration_of(table):
         table.RegenerateTableSuppressed = False
 
 @contextmanager
-def timing(message=u'Elapsed'):
+def timing(message='Elapsed'):
     """ Context manager for timing execution
 
     :param message: message to print
@@ -108,7 +108,7 @@ def timing(message=u'Elapsed'):
         yield begin
     finally:
         elapsed = (time.time() - begin)
-        print u'%s: %.3f s' % (message, elapsed)
+        print('%s: %.3f s' % (message, elapsed))
 
 
 

--- a/decodes/io/rhino_in.py
+++ b/decodes/io/rhino_in.py
@@ -2,7 +2,7 @@ from .. import *
 from ..core import *
 from ..core import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon, dc_xform
 import rhinoscriptsyntax as rs
-if VERBOSE_FS: print "rhino_in loaded"
+if VERBOSE_FS: print("rhino_in loaded")
 
 
 class RhinoIn():

--- a/decodes/io/rhino_out.py
+++ b/decodes/io/rhino_out.py
@@ -2,7 +2,7 @@ from .. import *
 from ..core import *
 from ..core import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_pline, dc_mesh, dc_pgon
 from . import outie
-if VERBOSE_FS: print "rhino_out loaded"
+if VERBOSE_FS: print("rhino_out loaded")
 
 import scriptcontext
 import Rhino
@@ -186,7 +186,7 @@ def makelayer(layer_name):
     import System
     layer_index = scriptcontext.doc.Layers.Find(layer_name, True)
     if layer_index>=0:
-        if VERBOSE_FS: print "already have a layer called ", layer_name
+        if VERBOSE_FS: print("already have a layer called ", layer_name)
         return layer_index
         
     layer_index = scriptcontext.doc.Layers.Add(layer_name, System.Drawing.Color.FromArgb(0,0,0))

--- a/decodes/io/rhinoscript/application.py
+++ b/decodes/io/rhinoscript/application.py
@@ -5,7 +5,7 @@ import Rhino.Commands.Command as rhcommand
 import System.TimeSpan, System.Enum
 import System.Windows.Forms.Screen
 import datetime
-import utility as rhutil
+from . import utility as rhutil
 
 
 def AddAlias(alias, macro):

--- a/decodes/io/rhinoscript/block.py
+++ b/decodes/io/rhinoscript/block.py
@@ -1,6 +1,6 @@
 import Rhino
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import math
 import System.Guid
 

--- a/decodes/io/rhinoscript/curve.py
+++ b/decodes/io/rhinoscript/curve.py
@@ -1,5 +1,5 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import Rhino
 import math
 import System.Guid, System.Array, System.Enum
@@ -312,12 +312,12 @@ def AddNurbsCurve(points, knots, degree, weights=None):
     rational = (weights!=None)
     
     nc = Rhino.Geometry.NurbsCurve(3,rational,degree+1,cvcount)
-    for i in xrange(cvcount):
+    for i in range(cvcount):
         cp = Rhino.Geometry.ControlPoint()
         cp.Location = points[i]
         if weights: cp.Weight = weights[i]
         nc.Points[i] = cp
-    for i in xrange(knotcount): nc.Knots[i] = knots[i]
+    for i in range(knotcount): nc.Knots[i] = knots[i]
     rc = scriptcontext.doc.Objects.AddCurve(nc)
     if rc==System.Guid.Empty: raise Exception("Unable to add curve to document")
     scriptcontext.doc.Views.Redraw()
@@ -897,7 +897,7 @@ def CurveCurveIntersection(curveA, curveB, tolerance=-1):
     rc = Rhino.Geometry.Intersect.Intersection.CurveCurve(curveA, curveB, tolerance, 0.0)
     events = []
     if rc:
-        for i in xrange(rc.Count):
+        for i in range(rc.Count):
             event_type = 1
             if( rc[i].IsOverlap ): event_type = 2
             oa = rc[i].OverlapA
@@ -1303,7 +1303,7 @@ def CurvePoints(curve_id, segment_index=-1):
     curve = rhutil.coercecurve(curve_id, segment_index, True)
     nc = curve.ToNurbsCurve()
     if nc is None: return scriptcontext.errorhandler()
-    points = [nc.Points[i].Location for i in xrange(nc.Points.Count)]
+    points = [nc.Points[i].Location for i in range(nc.Points.Count)]
     return points
 
 
@@ -1428,7 +1428,7 @@ def CurveSurfaceIntersection(curve_id, surface_id, tolerance=-1, angle_tolerance
     rc = Rhino.Geometry.Intersect.Intersection.CurveSurface(curve, surface, tolerance, angle_tolerance)
     events = []
     if rc:
-      for i in xrange(rc.Count):
+      for i in range(rc.Count):
           event_type = 2 if rc[i].IsOverlap else 1
           item = rc[i]
           oa = item.OverlapA

--- a/decodes/io/rhinoscript/dimension.py
+++ b/decodes/io/rhinoscript/dimension.py
@@ -1,8 +1,8 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import Rhino
 import System.Guid
-from view import __viewhelper
+from .view import __viewhelper
 
 
 def AddAlignedDimension(start_point, end_point, point_on_dimension_line, style=None):

--- a/decodes/io/rhinoscript/geometry.py
+++ b/decodes/io/rhinoscript/geometry.py
@@ -1,5 +1,5 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import Rhino
 import System.Guid, System.Array
 

--- a/decodes/io/rhinoscript/grips.py
+++ b/decodes/io/rhinoscript/grips.py
@@ -1,4 +1,4 @@
-import utility as rhutil
+from . import utility as rhutil
 import scriptcontext
 import Rhino
 
@@ -181,7 +181,7 @@ def SelectedObjectGrips(object_id):
     grips = rhobj.GetGrips()
     rc = []
     if grips:
-        for i in xrange(grips.Length):
+        for i in range(grips.Length):
             if grips[i].IsSelected(False): rc.append(i)
     return rc
 

--- a/decodes/io/rhinoscript/group.py
+++ b/decodes/io/rhinoscript/group.py
@@ -1,5 +1,5 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 
 def AddGroup(group_name=None):
     """Adds a new empty group to the document

--- a/decodes/io/rhinoscript/hatch.py
+++ b/decodes/io/rhinoscript/hatch.py
@@ -1,5 +1,5 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import Rhino
 import System.Guid
 

--- a/decodes/io/rhinoscript/layer.py
+++ b/decodes/io/rhinoscript/layer.py
@@ -1,6 +1,6 @@
 import Rhino.DocObjects.Layer
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import System.Guid
 
 

--- a/decodes/io/rhinoscript/light.py
+++ b/decodes/io/rhinoscript/light.py
@@ -1,5 +1,5 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import Rhino.Geometry
 import math
 

--- a/decodes/io/rhinoscript/line.py
+++ b/decodes/io/rhinoscript/line.py
@@ -1,5 +1,5 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import Rhino
 
 

--- a/decodes/io/rhinoscript/linetype.py
+++ b/decodes/io/rhinoscript/linetype.py
@@ -1,5 +1,5 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import Rhino
 
 
@@ -41,7 +41,7 @@ def LinetypeNames(sort=False):
     """
     count = scriptcontext.doc.Linetypes.Count
     rc = []
-    for i in xrange(count):
+    for i in range(count):
         linetype = scriptcontext.doc.Linetypes[i]
         if not linetype.IsDeleted: rc.append(linetype.Name)
     if sort: rc.sort()

--- a/decodes/io/rhinoscript/material.py
+++ b/decodes/io/rhinoscript/material.py
@@ -1,7 +1,7 @@
 import Rhino.DocObjects
 import scriptcontext
-import utility as rhutil
-from layer import __getlayer
+from . import utility as rhutil
+from .layer import __getlayer
 
 
 def AddMaterialToLayer(layer):

--- a/decodes/io/rhinoscript/mesh.py
+++ b/decodes/io/rhinoscript/mesh.py
@@ -1,5 +1,5 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import Rhino
 import System.Guid, System.Array, System.Drawing.Color
 
@@ -94,7 +94,7 @@ def CurveMeshIntersection(curve_id, mesh_id, return_faces=False):
     pts = list(pts)
     if return_faces:
         faceids = list(faceids)
-        return zip(pts, faceids)
+        return list(zip(pts, faceids))
     return pts
 
 
@@ -406,7 +406,7 @@ def MeshFaceNormals(mesh_id):
     if mesh.FaceNormals.Count != mesh.Faces.Count:
         mesh.FaceNormals.ComputeFaceNormals()
     rc = []
-    for i in xrange(mesh.FaceNormals.Count):
+    for i in range(mesh.FaceNormals.Count):
         normal = mesh.FaceNormals[i]
         rc.append(Rhino.Geometry.Vector3d(normal))
     return rc
@@ -427,7 +427,7 @@ def MeshFaces(object_id, face_type=True):
     """
     mesh = rhutil.coercemesh(object_id, True)
     rc = []
-    for i in xrange(mesh.Faces.Count):
+    for i in range(mesh.Faces.Count):
         getrc, p0, p1, p2, p3 = mesh.Faces.GetFaceVertices(i)
         p0 = Rhino.Geometry.Point3d(p0)
         p1 = Rhino.Geometry.Point3d(p1)
@@ -457,7 +457,7 @@ def MeshFaceVertices(object_id):
     """
     mesh = rhutil.coercemesh(object_id, True)
     rc = []
-    for i in xrange(mesh.Faces.Count):
+    for i in range(mesh.Faces.Count):
         face = mesh.Faces.GetFace(i)
         rc.append( (face.A, face.B, face.C, face.D) )
     return rc
@@ -651,7 +651,7 @@ def MeshVertexNormals(mesh_id):
     mesh = rhutil.coercemesh(mesh_id, True)
     count = mesh.Normals.Count
     if count<1: return []
-    return [Rhino.Geometry.Vector3d(mesh.Normals[i]) for i in xrange(count)]
+    return [Rhino.Geometry.Vector3d(mesh.Normals[i]) for i in range(count)]
 
 
 def MeshVertices(object_id):
@@ -664,7 +664,7 @@ def MeshVertices(object_id):
     mesh = rhutil.coercemesh(object_id, True)
     count = mesh.Vertices.Count
     rc = []
-    for i in xrange(count):
+    for i in range(count):
         vertex = mesh.Vertices[i]
         rc.append(Rhino.Geometry.Point3d(vertex))
     return rc

--- a/decodes/io/rhinoscript/object.py
+++ b/decodes/io/rhinoscript/object.py
@@ -1,8 +1,8 @@
 import scriptcontext
 import Rhino
-import utility as rhutil
+from . import utility as rhutil
 import System.Guid, System.Enum
-from layer import __getlayer
+from .layer import __getlayer
 
 
 def CopyObject(object_id, translation=None):

--- a/decodes/io/rhinoscript/plane.py
+++ b/decodes/io/rhinoscript/plane.py
@@ -1,4 +1,4 @@
-import utility as rhutil
+from . import utility as rhutil
 import Rhino.Geometry
 import scriptcontext
 import math

--- a/decodes/io/rhinoscript/pointvector.py
+++ b/decodes/io/rhinoscript/pointvector.py
@@ -1,4 +1,4 @@
-import utility as rhutil
+from . import utility as rhutil
 import Rhino
 import scriptcontext
 import math

--- a/decodes/io/rhinoscript/selection.py
+++ b/decodes/io/rhinoscript/selection.py
@@ -1,8 +1,8 @@
 import scriptcontext
 import Rhino
-import utility as rhutil
-import application as rhapp
-from layer import __getlayer
+from . import utility as rhutil
+from . import application as rhapp
+from .layer import __getlayer
 
 
 class filter:
@@ -311,7 +311,7 @@ def GetObjects(message=None, filter=0, group=True, preselect=False, select=False
         scriptcontext.doc.Views.Redraw()
     rc = []
     count = go.ObjectCount
-    for i in xrange(count):
+    for i in range(count):
         objref = go.Object(i)
         rc.append(objref.ObjectId)
         obj = objref.Object()
@@ -363,7 +363,7 @@ def GetObjectsEx(message=None, filter=0, group=True, preselect=False, select=Fal
         scriptcontext.doc.Views.Redraw()
     rc = []
     count = go.ObjectCount
-    for i in xrange(count):
+    for i in range(count):
         objref = go.Object(i)
         id = objref.ObjectId
         presel = go.ObjectsWerePreselected

--- a/decodes/io/rhinoscript/surface.py
+++ b/decodes/io/rhinoscript/surface.py
@@ -2,8 +2,8 @@ import scriptcontext
 import math
 import Rhino
 import System.Guid
-import utility as rhutil
-import object as rhobject
+from . import utility as rhutil
+from . import object as rhobject
 
 def AddBox(corners):
     """Adds a new box shaped polysurface to the document

--- a/decodes/io/rhinoscript/transformation.py
+++ b/decodes/io/rhinoscript/transformation.py
@@ -1,9 +1,9 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import Rhino
 import System.Guid, System.Array
 import math
-import view as rhview
+from . import view as rhview
 
 
 def IsXformIdentity(xform):

--- a/decodes/io/rhinoscript/userdata.py
+++ b/decodes/io/rhinoscript/userdata.py
@@ -1,5 +1,5 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 
 def DeleteDocumentData(section=None, entry=None):
     """Removes user data strings from the current document

--- a/decodes/io/rhinoscript/userinterface.py
+++ b/decodes/io/rhinoscript/userinterface.py
@@ -1,11 +1,11 @@
 import Rhino
-import utility as rhutil
+from . import utility as rhutil
 import scriptcontext
 import System.Drawing.Color
 import System.Enum
 import System.Array
 import System.Windows.Forms
-from view import __viewhelper
+from .view import __viewhelper
 
 
 def BrowseForFolder(folder=None, message=None, title=None):
@@ -45,7 +45,7 @@ def CheckListBox(items, message=None, title=None):
     itemstrs = [str(item[0]) for item in items]
     newcheckstates = Rhino.UI.Dialogs.ShowCheckListBox(title, message, itemstrs, checkstates)
     if newcheckstates:
-        rc = zip(itemstrs, newcheckstates)
+        rc = list(zip(itemstrs, newcheckstates))
         return rc
     return scriptcontext.errorhandler()
 

--- a/decodes/io/rhinoscript/utility.py
+++ b/decodes/io/rhinoscript/utility.py
@@ -24,7 +24,7 @@ def ContextIsGrasshopper():
 #should work all of the time unless we can't find the standard lib
 __cfparse = None
 try:
-    import ConfigParser
+    import configparser
 except ImportError:
     __cfparse = None
 else:
@@ -229,7 +229,7 @@ def GetSettings(filename, section=None, entry=None):
     """
     if __cfparse is None: return scriptcontext.errorhandler()
     try:
-        cp = ConfigParser.ConfigParser()
+        cp = configparser.ConfigParser()
         cp.read(filename)
         if not section: return cp.sections()
         section = string.lower(section)
@@ -410,11 +410,11 @@ def coerce3dpointlist(points, raise_on_error=False):
     if type(points) is list or type(points) is tuple:
         count = len(points)
         if count>0 and (coerce3dpoint(points[0]) is not None):
-            return [coerce3dpoint(points[i], raise_on_error) for i in xrange(count)]
+            return [coerce3dpoint(points[i], raise_on_error) for i in range(count)]
         elif count>2 and type(points[0]) is not list:
             point_count = count/3
             rc = []
-            for i in xrange(point_count):
+            for i in range(point_count):
                 pt = Rhino.Geometry.Point3d(points[i*3], points[i*3+1], points[i*3+2])
                 rc.append(pt)
             return rc
@@ -428,18 +428,18 @@ def coerce2dpointlist(points):
         count = len(points)
         if count>0 and type(points[0]) is Rhino.Geometry.Point2d:
             rc = System.Array.CreateInstance(Rhino.Geometry.Point2d, count)
-            for i in xrange(count): rc[i] = points[i]
+            for i in range(count): rc[i] = points[i]
             return rc
         elif count>1 and type(points[0]) is not list:
             point_count = count/2
             rc = System.Array.CreateInstance(Rhino.Geometry.Point2d,point_count)
-            for i in xrange(point_count):
+            for i in range(point_count):
                 rc[i] = Rhino.Geometry.Point2d(points[i*2], points[i*2+1])
             return rc
         elif count>0 and type(points[0]) is list:
             point_count = count
             rc = System.Array.CreateInstance(Rhino.Geometry.Point2d,point_count)
-            for i in xrange(point_count):
+            for i in range(point_count):
                 pt = points[i]
                 rc[i] = Rhino.Geometry.Point2d(pt[0],pt[1])
             return rc

--- a/decodes/io/rhinoscript/view.py
+++ b/decodes/io/rhinoscript/view.py
@@ -1,5 +1,5 @@
 import scriptcontext
-import utility as rhutil
+from . import utility as rhutil
 import Rhino
 import System.Enum
 import math

--- a/decodes/io/svg_out.py
+++ b/decodes/io/svg_out.py
@@ -2,10 +2,10 @@ from .. import *
 from ..core import *
 from ..core import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon
 from . import outie
-if VERBOSE_FS: print "svg_out loaded"
+if VERBOSE_FS: print("svg_out loaded")
 
 import os, sys, math
-import cStringIO
+import io
 
 class SVGOut(outie.Outie):
     """outie for writing stuff to a SVG file"""
@@ -32,10 +32,10 @@ class SVGOut(outie.Outie):
         self.svg = False
 
     def _startDraw(self):
-        if self._verbose: print "building svg string"
+        if self._verbose: print("building svg string")
         self.svg = False
         
-        self.buffer = cStringIO.StringIO()
+        self.buffer = io.StringIO()
         svg_size = ""
         if self._canvas_dim is not False: svg_size = 'width="'+str(self._canvas_dim.a)+'" height="'+str(self._canvas_dim.b)+'"'
         self.buffer.write('<svg '+svg_size+' xmlns="http://www.w3.org/2000/svg" version="1.1">\n')
@@ -45,7 +45,7 @@ class SVGOut(outie.Outie):
         self.svg = self.buffer.getvalue()
         
         if self._save_file: 
-            if self._verbose: print "drawing svg to "+self.filepath
+            if self._verbose: print("drawing svg to "+self.filepath)
             # write buffer to file
             fo = open(self.filepath, "wb")
             fo.write( self.svg )

--- a/decodes/io/threejs_out.py
+++ b/decodes/io/threejs_out.py
@@ -2,10 +2,10 @@ from .. import *
 from ..core import *
 from ..core import dc_base, dc_vec, dc_point, dc_cs, dc_line, dc_mesh, dc_pgon
 from . import outie
-if VERBOSE_FS: print "threejs_out loaded"
+if VERBOSE_FS: print("threejs_out loaded")
 
 import os, sys, math
-import cStringIO
+import io
 
 class ThreeJSOut(outie.Outie):
     """outie for writing stuff to a ThreeJS scene file"""
@@ -28,10 +28,10 @@ class ThreeJSOut(outie.Outie):
         self.jsonstr = False
 
     def _startDraw(self):
-        print "building 3js string"
+        print("building 3js string")
         self.jsonstr = False
         
-        self.buffer = cStringIO.StringIO()
+        self.buffer = io.StringIO()
         self.buffer.write('{\n"metadata":{},\n')
     
     def _endDraw(self):
@@ -39,7 +39,7 @@ class ThreeJSOut(outie.Outie):
         self.jsonstr = self.buffer.getvalue()
         
         if self._save_file: 
-            print "drawing 3js to "+self.filepath
+            print("drawing 3js to "+self.filepath)
             # write buffer to file
             fo = open(self.filepath, "wb")
             fo.write( self.jsonstr )

--- a/decodes/test/__init__.py
+++ b/decodes/test/__init__.py
@@ -1,4 +1,4 @@
-print "unit_tests loaded"
+print("unit_tests loaded")
 import unittest, importlib, sys, inspect, os
 
 

--- a/decodes/test/__init__.py
+++ b/decodes/test/__init__.py
@@ -10,7 +10,7 @@ filename = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe(
 logfile = open(filename, "w")
 for submod in __all__:
     logfile.write( "\n\n== "+submod.upper()+" ==\n" )
-    mod = importlib.import_module("decodes.unit_tests."+submod)
+    mod = importlib.import_module("decodes.test."+submod)
     suite = unittest.TestLoader().loadTestsFromTestCase(mod.Tests)
     unittest.TextTestRunner(logfile,verbosity=2).run(suite)
 logfile.close

--- a/decodes/test/log.txt
+++ b/decodes/test/log.txt
@@ -1,225 +1,303 @@
 
 
 == TEST_VOXEL ==
-test_bounds_and_cpt (decodes.unit_tests.test_voxel.Tests) ... FAIL
-test_constructor (decodes.unit_tests.test_voxel.Tests) ... ok
+test_bounds_and_cpt (decodes.test.test_voxel.Tests) ... FAIL
+test_constructor (decodes.test.test_voxel.Tests) ... ok
 
 ======================================================================
-FAIL: test_bounds_and_cpt (decodes.unit_tests.test_voxel.Tests)
+FAIL: test_bounds_and_cpt (decodes.test.test_voxel.Tests)
 ----------------------------------------------------------------------
 Traceback (most recent call last):
-  File "G:\git\decodes\decodes\unit_tests\test_voxel.py", line 26, in test_bounds_and_cpt
+  File "c:\home\code\python\sniffer\decodes\test\test_voxel.py", line 26, in test_bounds_and_cpt
     self.assertEqual(vf.dim_pixel,Vec(3,3,2))
 AssertionError: vec[1.0,1.0,1.0] != vec[3,3,2]
 
 ----------------------------------------------------------------------
-Ran 2 tests in 0.005s
+Ran 2 tests in 0.001s
 
 FAILED (failures=1)
 
 
 == TEST_XSECT ==
-test_bad_combonations (decodes.unit_tests.test_xsect.Tests) ... ok
-test_circ_circ (decodes.unit_tests.test_xsect.Tests) ... ok
-test_line_line (decodes.unit_tests.test_xsect.Tests) ... ok
-test_line_plane (decodes.unit_tests.test_xsect.Tests) ... ok
-test_plane_plane (decodes.unit_tests.test_xsect.Tests) ... FAIL
-test_ray_pgon (decodes.unit_tests.test_xsect.Tests) ... ok
-test_ray_plane (decodes.unit_tests.test_xsect.Tests) ... ok
-test_seg_plane (decodes.unit_tests.test_xsect.Tests) ... ok
+test_bad_combonations (decodes.test.test_xsect.Tests) ... ok
+test_circ_circ (decodes.test.test_xsect.Tests) ... ok
+test_line_line (decodes.test.test_xsect.Tests) ... ok
+test_line_plane (decodes.test.test_xsect.Tests) ... FAIL
+test_plane_plane (decodes.test.test_xsect.Tests) ... FAIL
+test_ray_pgon (decodes.test.test_xsect.Tests) ... FAIL
+test_ray_plane (decodes.test.test_xsect.Tests) ... ok
+test_seg_plane (decodes.test.test_xsect.Tests) ... FAIL
 
 ======================================================================
-FAIL: test_plane_plane (decodes.unit_tests.test_xsect.Tests)
+FAIL: test_line_plane (decodes.test.test_xsect.Tests)
 ----------------------------------------------------------------------
 Traceback (most recent call last):
-  File "G:\git\decodes\decodes\unit_tests\test_xsect.py", line 136, in test_plane_plane
+  File "c:\home\code\python\sniffer\decodes\test\test_xsect.py", line 53, in test_line_plane
+    self.assertEqual(xsec.of(line,pln),False)
+AssertionError: True != False
+
+======================================================================
+FAIL: test_plane_plane (decodes.test.test_xsect.Tests)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "c:\home\code\python\sniffer\decodes\test\test_xsect.py", line 136, in test_plane_plane
     self.assertEqual(xsec[0].vec.is_parallel(ln.vec),True) # lines are parallel
 AssertionError: False != True
 
+======================================================================
+FAIL: test_ray_pgon (decodes.test.test_xsect.Tests)
 ----------------------------------------------------------------------
-Ran 8 tests in 0.184s
+Traceback (most recent call last):
+  File "c:\home\code\python\sniffer\decodes\test\test_xsect.py", line 104, in test_ray_pgon
+    self.assertEqual(xsec.of(ray,pgon),False)
+AssertionError: None != False
 
-FAILED (failures=1)
+======================================================================
+FAIL: test_seg_plane (decodes.test.test_xsect.Tests)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "c:\home\code\python\sniffer\decodes\test\test_xsect.py", line 81, in test_seg_plane
+    self.assertEqual(xsec.of(seg,pln),False)
+AssertionError: True != False
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.009s
+
+FAILED (failures=4)
 
 
 == TEST_CLASSICAL_SURFACE ==
-test_rotational (decodes.unit_tests.test_classical_surface.Tests) ... ERROR
+test_rotational (decodes.test.test_classical_surface.Tests) ... ERROR
 
 ======================================================================
-ERROR: test_rotational (decodes.unit_tests.test_classical_surface.Tests)
+ERROR: test_rotational (decodes.test.test_classical_surface.Tests)
 ----------------------------------------------------------------------
 Traceback (most recent call last):
-  File "G:\git\decodes\decodes\unit_tests\test_classical_surface.py", line 19, in test_rotational
-    iso = rot_surf.isocurve(u_val=0.25)
-  File "G:\git\decodes\decodes\extensions\classical_surfaces.py", line 87, in isocurve
-    pt_1 = self.axis.to_line().near_pt(pt_0)
-AttributeError: 'Curve' object has no attribute 'to_line'
+  File "c:\home\code\python\sniffer\decodes\test\test_classical_surface.py", line 13, in test_rotational
+    rot_surf = RotationalSurface(cs,crv)
+  File "c:\home\code\python\sniffer\decodes\extensions\classical_surfaces.py", line 44, in __init__
+    self.center = axis._pt
+AttributeError: 'Curve' object has no attribute '_pt'
 
 ----------------------------------------------------------------------
-Ran 1 test in 0.026s
+Ran 1 test in 0.001s
 
 FAILED (errors=1)
 
 
 == TEST_PGON ==
-test_bounds (decodes.unit_tests.test_pgon.Tests) ... ok
-test_containment (decodes.unit_tests.test_pgon.Tests) ... ok
-test_empty_constructor (decodes.unit_tests.test_pgon.Tests) ... ERROR
-test_inflation (decodes.unit_tests.test_pgon.Tests) ... ok
-test_rgon_construction (decodes.unit_tests.test_pgon.Tests) ... ok
-test_rgon_to_pgon (decodes.unit_tests.test_pgon.Tests) ... ok
-test_segs_and_edges (decodes.unit_tests.test_pgon.Tests) ... ok
+test_bounds (decodes.test.test_pgon.Tests) ... ok
+test_containment (decodes.test.test_pgon.Tests) ... ok
+test_empty_constructor (decodes.test.test_pgon.Tests) ... ERROR
+test_inflation (decodes.test.test_pgon.Tests) ... ok
+test_rgon_construction (decodes.test.test_pgon.Tests) ... ok
+test_rgon_to_pgon (decodes.test.test_pgon.Tests) ... ok
+test_segs_and_edges (decodes.test.test_pgon.Tests) ... FAIL
 
 ======================================================================
-ERROR: test_empty_constructor (decodes.unit_tests.test_pgon.Tests)
+ERROR: test_empty_constructor (decodes.test.test_pgon.Tests)
 ----------------------------------------------------------------------
 Traceback (most recent call last):
-  File "G:\git\decodes\decodes\unit_tests\test_pgon.py", line 9, in test_empty_constructor
+  File "c:\home\code\python\sniffer\decodes\test\test_pgon.py", line 9, in test_empty_constructor
     pgon = PGon()
-  File "G:\git\decodes\decodes\core\dc_pgon.py", line 26, in __init__
-    if basis is None and vertices is None : raise GeometricError("You must define both a basis and a list of vertices to construct a PGon")
-GeometricError: You must define both a basis and a list of vertices to construct a PGon
+  File "c:\home\code\python\sniffer\decodes\core\dc_pgon.py", line 36, in __init__
+    if basis is None and vertices is None : raise GeometricError("You must define either a basis or a list of vertices (or both) to construct a PGon")
+decodes.core.dc_base.GeometricError: You must define either a basis or a list of vertices (or both) to construct a PGon
+
+======================================================================
+FAIL: test_segs_and_edges (decodes.test.test_pgon.Tests)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "c:\home\code\python\sniffer\decodes\test\test_pgon.py", line 27, in test_segs_and_edges
+    func(0,Segment(Point(0,0,3),Point(1,0,3)))
+  File "c:\home\code\python\sniffer\decodes\test\test_pgon.py", line 22, in func
+    self.assertEqual(seg.spt,pgon.seg(n).spt)
+AssertionError: pt[0,0,3] != pt[0.0,0.0,2.0]
 
 ----------------------------------------------------------------------
-Ran 7 tests in 0.181s
+Ran 7 tests in 0.007s
+
+FAILED (failures=1, errors=1)
+
+
+== TEST_PLINE ==
+test_empty_constructor (decodes.test.test_pline.Tests) ... ERROR
+test_segs_and_edges (decodes.test.test_pline.Tests) ... ok
+
+======================================================================
+ERROR: test_empty_constructor (decodes.test.test_pline.Tests)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "c:\home\code\python\sniffer\decodes\test\test_pline.py", line 9, in test_empty_constructor
+    pline = PLine()
+  File "c:\home\code\python\sniffer\decodes\core\dc_pline.py", line 31, in __init__
+    if vertices is None or len(vertices)<2: raise GeometricError("Plines must be constructed with at least two points")
+decodes.core.dc_base.GeometricError: Plines must be constructed with at least two points
+
+----------------------------------------------------------------------
+Ran 2 tests in 0.003s
 
 FAILED (errors=1)
 
 
-== TEST_PLINE ==
-test_empty_constructor (decodes.unit_tests.test_pline.Tests) ... ok
-test_segs_and_edges (decodes.unit_tests.test_pline.Tests) ... ok
-
-----------------------------------------------------------------------
-Ran 2 tests in 0.079s
-
-OK
-
-
 == TEST_MESH ==
-test_empty_constructor (decodes.unit_tests.test_mesh.Tests) ... ok
-test_explode (decodes.unit_tests.test_mesh.Tests) ... ok
-test_face_access (decodes.unit_tests.test_mesh.Tests) ... ok
-test_simple_constructor (decodes.unit_tests.test_mesh.Tests) ... ok
+test_empty_constructor (decodes.test.test_mesh.Tests) ... ok
+test_explode (decodes.test.test_mesh.Tests) ... ok
+test_face_access (decodes.test.test_mesh.Tests) ... ok
+test_simple_constructor (decodes.test.test_mesh.Tests) ... ok
 
 ----------------------------------------------------------------------
-Ran 4 tests in 0.029s
+Ran 4 tests in 0.002s
 
 OK
 
 
 == TEST_POINT ==
-test_based_constructor (decodes.unit_tests.test_point.Tests) ... ok
-test_cull_dups (decodes.unit_tests.test_point.Tests) ... ok
-test_cull_dups2 (decodes.unit_tests.test_point.Tests) ... ok
-test_empty_constructor (decodes.unit_tests.test_point.Tests) ... ok
-test_nearest_point (decodes.unit_tests.test_point.Tests) ... ok
+test_based_constructor (decodes.test.test_point.Tests) ... ERROR
+test_cull_dups (decodes.test.test_point.Tests) ... ok
+test_cull_dups2 (decodes.test.test_point.Tests) ... ok
+test_empty_constructor (decodes.test.test_point.Tests) ... ok
+test_nearest_point (decodes.test.test_point.Tests) ... ok
+
+======================================================================
+ERROR: test_based_constructor (decodes.test.test_point.Tests)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "c:\home\code\python\sniffer\decodes\test\test_point.py", line 14, in test_based_constructor
+    pta = BPoint(0,0,0,basis=CS(Point(2,2,2)))
+NameError: name 'BPoint' is not defined
 
 ----------------------------------------------------------------------
-Ran 5 tests in 0.030s
+Ran 5 tests in 0.001s
 
-OK
+FAILED (errors=1)
 
 
 == TEST_HAS_PTS ==
-test_appending_points (decodes.unit_tests.test_has_pts.Tests) ... ok
-test_basis_applied_and_stripped (decodes.unit_tests.test_has_pts.Tests) ... ok
-test_centroid (decodes.unit_tests.test_has_pts.Tests) ... ok
-test_item_access (decodes.unit_tests.test_has_pts.Tests) ... ok
-test_manipulating_points (decodes.unit_tests.test_has_pts.Tests) ... ok
-test_swap_basis (decodes.unit_tests.test_has_pts.Tests) ... ok
-test_unsetting (decodes.unit_tests.test_has_pts.Tests) ... ok
+test_appending_points (decodes.test.test_has_pts.Tests) ... ERROR
+test_basis_applied_and_stripped (decodes.test.test_has_pts.Tests) ... ok
+test_centroid (decodes.test.test_has_pts.Tests) ... ok
+test_item_access (decodes.test.test_has_pts.Tests) ... ok
+test_manipulating_points (decodes.test.test_has_pts.Tests) ... FAIL
+test_swap_basis (decodes.test.test_has_pts.Tests) ... ok
+test_unsetting (decodes.test.test_has_pts.Tests) ... ok
+
+======================================================================
+ERROR: test_appending_points (decodes.test.test_has_pts.Tests)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "c:\home\code\python\sniffer\decodes\test\test_has_pts.py", line 52, in test_appending_points
+    pgon = PGon(basis=CS(1,2,3))
+  File "c:\home\code\python\sniffer\decodes\core\dc_pgon.py", line 58, in __init__
+    super(PGon,self).__init__([Vec(v.x,v.y) for v in vertices],basis) #HasPts constructor handles initialization of verts and basis
+TypeError: 'NoneType' object is not iterable
+
+======================================================================
+FAIL: test_manipulating_points (decodes.test.test_has_pts.Tests)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "c:\home\code\python\sniffer\decodes\test\test_has_pts.py", line 72, in test_manipulating_points
+    self.assertEqual(Point(1,0,-1),pgon.pts[1],"access via the pts function returns a list of point objects, which does not permit manipulation")
+AssertionError: pt[1,0,-1] != pt[1.0,0.0,88] : access via the pts function returns a list of point objects, which does not permit manipulation
 
 ----------------------------------------------------------------------
-Ran 7 tests in 0.152s
+Ran 7 tests in 0.008s
 
-OK
+FAILED (failures=1, errors=1)
 
 
 == TEST_CURVE ==
-test_bezier (decodes.unit_tests.test_curve.Tests) ... ok
-test_constructor (decodes.unit_tests.test_curve.Tests) ... ok
-test_division (decodes.unit_tests.test_curve.Tests) ... ok
-test_far (decodes.unit_tests.test_curve.Tests) ... ok
-test_hermite (decodes.unit_tests.test_curve.Tests) ... ok
-test_near (decodes.unit_tests.test_curve.Tests) ... ok
-test_subdivide (decodes.unit_tests.test_curve.Tests) ... ok
-test_tolerance (decodes.unit_tests.test_curve.Tests) ... ok
+test_bezier (decodes.test.test_curve.Tests) ... ok
+test_constructor (decodes.test.test_curve.Tests) ... ok
+test_division (decodes.test.test_curve.Tests) ... ok
+test_far (decodes.test.test_curve.Tests) ... ok
+test_hermite (decodes.test.test_curve.Tests) ... ok
+test_near (decodes.test.test_curve.Tests) ... ok
+test_subdivide (decodes.test.test_curve.Tests) ... ok
+test_tolerance (decodes.test.test_curve.Tests) ... ok
 
 ----------------------------------------------------------------------
-Ran 8 tests in 0.885s
+Ran 8 tests in 0.029s
 
 OK
 
 
 == TEST_SURFACE ==
-test_curvature (decodes.unit_tests.test_surface.Tests) ... ok
-test_iso_curvature (decodes.unit_tests.test_surface.Tests) ... ok
+test_curvature (decodes.test.test_surface.Tests) ... ok
+test_iso_curvature (decodes.test.test_surface.Tests) ... ok
 
 ----------------------------------------------------------------------
-Ran 2 tests in 0.346s
+Ran 2 tests in 0.010s
 
 OK
 
 
 == TEST_PLANE ==
-test_copy_constructors (decodes.unit_tests.test_plane.Tests) ... ok
-test_dist_from_origin (decodes.unit_tests.test_plane.Tests) ... ok
-test_empty_constructor (decodes.unit_tests.test_plane.Tests) ... ok
-test_near (decodes.unit_tests.test_plane.Tests) ... ok
-test_xform (decodes.unit_tests.test_plane.Tests) ... ok
+test_copy_constructors (decodes.test.test_plane.Tests) ... ok
+test_dist_from_origin (decodes.test.test_plane.Tests) ... ok
+test_empty_constructor (decodes.test.test_plane.Tests) ... ok
+test_near (decodes.test.test_plane.Tests) ... ok
+test_xform (decodes.test.test_plane.Tests) ... ok
 
 ----------------------------------------------------------------------
-Ran 5 tests in 0.016s
+Ran 5 tests in 0.002s
 
 OK
 
 
 == TEST_INTERVAL ==
-test_empty_constructor (decodes.unit_tests.test_interval.Tests) ... ok
-test_operations (decodes.unit_tests.test_interval.Tests) ... ok
-test_properties (decodes.unit_tests.test_interval.Tests) ... ok
+test_empty_constructor (decodes.test.test_interval.Tests) ... ok
+test_operations (decodes.test.test_interval.Tests) ... ok
+test_properties (decodes.test.test_interval.Tests) ... ok
 
 ----------------------------------------------------------------------
-Ran 3 tests in 0.003s
+Ran 3 tests in 0.001s
 
 OK
 
 
 == TEST_LINE ==
-test_line (decodes.unit_tests.test_line.Tests) ... ok
-test_near_pt (decodes.unit_tests.test_line.Tests) ... ok
-test_ray (decodes.unit_tests.test_line.Tests) ... ok
-test_segment (decodes.unit_tests.test_line.Tests) ... ok
+test_line (decodes.test.test_line.Tests) ... ERROR
+test_near_pt (decodes.test.test_line.Tests) ... ok
+test_ray (decodes.test.test_line.Tests) ... ok
+test_segment (decodes.test.test_line.Tests) ... ok
+
+======================================================================
+ERROR: test_line (decodes.test.test_line.Tests)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "c:\home\code\python\sniffer\decodes\test\test_line.py", line 21, in test_line
+    self.assertEqual(line.ept,Point(1,0,0))
+AttributeError: 'Line' object has no attribute 'ept'
 
 ----------------------------------------------------------------------
-Ran 4 tests in 0.016s
+Ran 4 tests in 0.002s
 
-OK
+FAILED (errors=1)
 
 
 == TEST_VEC ==
-test_angle (decodes.unit_tests.test_vec.Tests) ... ok
-test_dot_and_cross_products (decodes.unit_tests.test_vec.Tests) ... ok
-test_empty_constructor (decodes.unit_tests.test_vec.Tests) ... ok
-test_normalizing (decodes.unit_tests.test_vec.Tests) ... ok
-test_operators (decodes.unit_tests.test_vec.Tests) ... ok
-test_properties (decodes.unit_tests.test_vec.Tests) ... ok
-test_static (decodes.unit_tests.test_vec.Tests) ... ok
+test_angle (decodes.test.test_vec.Tests) ... ok
+test_dot_and_cross_products (decodes.test.test_vec.Tests) ... ok
+test_empty_constructor (decodes.test.test_vec.Tests) ... ok
+test_normalizing (decodes.test.test_vec.Tests) ... ok
+test_operators (decodes.test.test_vec.Tests) ... ok
+test_properties (decodes.test.test_vec.Tests) ... ok
+test_static (decodes.test.test_vec.Tests) ... ok
 
 ----------------------------------------------------------------------
-Ran 7 tests in 0.012s
+Ran 7 tests in 0.001s
 
 OK
 
 
 == TEST_XFORM ==
-test_mirror (decodes.unit_tests.test_xform.Tests) ... ok
-test_scale (decodes.unit_tests.test_xform.Tests) ... ok
-test_translation (decodes.unit_tests.test_xform.Tests) ... ok
-test_xform_hasbasis (decodes.unit_tests.test_xform.Tests) ... ok
+test_mirror (decodes.test.test_xform.Tests) ... ok
+test_scale (decodes.test.test_xform.Tests) ... ok
+test_translation (decodes.test.test_xform.Tests) ... ok
+test_xform_hasbasis (decodes.test.test_xform.Tests) ... ok
 
 ----------------------------------------------------------------------
-Ran 4 tests in 0.017s
+Ran 4 tests in 0.001s
 
 OK


### PR DESCRIPTION
Changes to enable the library to run in python 3, while keeping it compatible with python 2.
Versions tested were 3.4.4 for python 3 and 2.7.12 for python 2.
Most changes were done by 2to3.py. Only one manual fix in dc_tri.py, due to the changes in the `from x import *` funcionality. Also a very small fix in the verbose_fs behavior.
The module imported on both versions. 
I ran the unit tests on both versions and there was many errors, but from what i could see they were not related to the compatibility fixes. The tests module itself required some maintenance before i could run... in some point the module changed from decodes.unit_test to decodes.test but a constant in the **init**.py was unchanged.
